### PR TITLE
Fix rbenv settings in ubuntu

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -14,7 +14,7 @@ function setup_rbenv {
             PATH=~/.rbenv/bin:$PATH
             eval "$(rbenv init -)"
             # Store rbenv init settings for other steps
-            rbenv init 2> ~/.bashrc
+            ~/.rbenv/bin/rbenv init 2> ~/.bashrc
             ;;
         *)
             echo "ERROR: Unknown platform found ${platform}"

--- a/step.sh
+++ b/step.sh
@@ -17,8 +17,8 @@ function setup_rbenv {
             wget -q "https://github.com/rbenv/rbenv-installer/raw/HEAD/bin/rbenv-doctor" -O- | bash
 
             # Store rbenv init settings for other steps
-            ~/.rbenv/bin/rbenv init bash 2> ~/.bashrc || echo "Set up ~/.bashrc for rbenv"
-            ~/.rbenv/bin/rbenv init zsh 2> ~/.zshrc || echo "Set up ~/.zshrc for rbenv"
+            ~/.rbenv/bin/rbenv init bash 2>> ~/.bashrc || echo "Set up ~/.bashrc for rbenv"
+            ~/.rbenv/bin/rbenv init zsh 2>> ~/.zshrc || echo "Set up ~/.zshrc for rbenv"
             ;;
         *)
             echo "ERROR: Unknown platform found ${platform}"

--- a/step.sh
+++ b/step.sh
@@ -13,7 +13,8 @@ function setup_rbenv {
             curl -fsSL https://github.com/rbenv/rbenv-installer/raw/HEAD/bin/rbenv-installer | bash
             PATH=~/.rbenv/bin:$PATH
             eval "$(rbenv init -)"
-            rbenv init bash 2> ~/.bashrc
+            # Store rbenv init settings for other steps
+            rbenv init 2> ~/.bashrc
             ;;
         *)
             echo "ERROR: Unknown platform found ${platform}"

--- a/step.sh
+++ b/step.sh
@@ -13,6 +13,8 @@ function setup_rbenv {
             curl -fsSL https://github.com/rbenv/rbenv-installer/raw/HEAD/bin/rbenv-installer | bash
             PATH=~/.rbenv/bin:$PATH
             eval "$(rbenv init -)"
+
+            wget -q "https://github.com/rbenv/rbenv-installer/raw/HEAD/bin/rbenv-doctor" -O- | bash
             # Store rbenv init settings for other steps
             ~/.rbenv/bin/rbenv init 2> ~/.bashrc
             ;;

--- a/step.sh
+++ b/step.sh
@@ -15,8 +15,10 @@ function setup_rbenv {
             eval "$(rbenv init -)"
 
             wget -q "https://github.com/rbenv/rbenv-installer/raw/HEAD/bin/rbenv-doctor" -O- | bash
+
             # Store rbenv init settings for other steps
-            ~/.rbenv/bin/rbenv init 2> ~/.bashrc
+            ~/.rbenv/bin/rbenv init bash 2> ~/.bashrc || echo "Set up ~/.bashrc for rbenv"
+            ~/.rbenv/bin/rbenv init zsh 2> ~/.zshrc || echo "Set up ~/.zshrc for rbenv"
             ;;
         *)
             echo "ERROR: Unknown platform found ${platform}"

--- a/step.sh
+++ b/step.sh
@@ -13,6 +13,7 @@ function setup_rbenv {
             curl -fsSL https://github.com/rbenv/rbenv-installer/raw/HEAD/bin/rbenv-installer | bash
             PATH=~/.rbenv/bin:$PATH
             eval "$(rbenv init -)"
+            rbenv init bash 2> ~/.bashrc
             ;;
         *)
             echo "ERROR: Unknown platform found ${platform}"


### PR DESCRIPTION
While rbenv is a built-in tool in macOS env, it's not in Ubuntu stack. We have to set up shell configuration that persists over other steps so that we can consistently use the same version.  